### PR TITLE
Add code coverage infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -341,3 +341,6 @@ healthchecksdb
 
 # Claude Code local settings (machine-specific overrides)
 .claude/settings.local.json
+
+# Code coverage output
+coverage/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,16 +5,10 @@ Conway's Game of Life implemented as a C# console application with a retro 80s a
 ## Tech Stack
 
 - **Language:** C# targeting .NET 10
-- **Test framework:** MSTest v3.x
+- **Test framework:** MSTest v4.x
 - **Build/test:** `dotnet` CLI
 
-## Build & Test
-
-```bash
-dotnet build       # build the project
-dotnet test        # run all tests
-dotnet run         # start the simulation
-```
+See `README.md` for build, test, and coverage commands.
 
 ## C# Conventions
 

--- a/Game-Of-Life.csproj
+++ b/Game-Of-Life.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.*" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.11.*" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.11.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.*" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.1.*" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.*" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -15,3 +15,21 @@ dotnet build    # build the project
 dotnet test     # run all tests
 dotnet run      # start the simulation
 ```
+
+## Coverage
+
+Requires two one-time global tool installs:
+
+```bash
+dotnet tool install -g dotnet-coverage
+dotnet tool install -g dotnet-reportgenerator-globaltool
+```
+
+Run tests with coverage collection, then generate the HTML report:
+
+```bash
+dotnet-coverage collect "dotnet test" -f cobertura -o coverage/coverage.cobertura.xml
+reportgenerator "-reports:coverage/coverage.cobertura.xml" "-targetdir:coverage/report" -reporttypes:Html
+```
+
+Open `coverage/report/index.html` to view the results.


### PR DESCRIPTION
## Summary

- Upgrades MSTest from 3.11.1 to 4.1.0 (fixes `MissingFieldException: TestContext.TestRunDirectoryLabel` — a packaging bug in 3.11.1 where the adapter referenced a field not present in the framework DLL)
- Adopts `dotnet-coverage` + `reportgenerator` as the coverage toolchain (`coverlet.collector` produced empty output for this single-project EXE type)
- Adds a Coverage section to `README.md` with the two commands needed to collect and view results
- Removes the duplicate Build & Test commands from `CLAUDE.md`, replacing with a reference to `README.md`
- Adds `coverage/` to `.gitignore`

## Baseline coverage (17 tests, pre Plan 2)

| Class | Line | Branch |
|---|---|---|
| `Cell.cs` | 100% | 100% |
| `Helper.cs` | 98% | 96% |
| `Life.cs` | 95% | 100% |
| `Patterns.cs` | 100% | 100% |

## Test plan

- [ ] `dotnet test` → 17 tests pass
- [ ] `dotnet-coverage collect "dotnet test" -f cobertura -o coverage/coverage.cobertura.xml` → produces non-empty XML
- [ ] `reportgenerator "-reports:coverage/coverage.cobertura.xml" "-targetdir:coverage/report" -reporttypes:Html` → `coverage/report/index.html` opens and shows per-class rates matching the table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)