### PR TITLE
Add missing permission rules for coverage and GitHub CLI tools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,6 +36,14 @@
       "Bash(dotnet publish:*)",
       "Bash(dotnet new:*)",
       "Bash(dotnet tool:*)",
+      "Bash(dotnet package:*)",
+      "Bash(dotnet-coverage:*)",
+      "Bash(reportgenerator:*)",
+
+      "Bash(gh pr create:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh run view:*)",
 
       "Bash(ls:*)",
       "Bash(find:*)",


### PR DESCRIPTION
## Summary

- Adds `dotnet-coverage` and `reportgenerator` to the `allow` list — both used in the coverage workflow and neither is destructive
- Adds `dotnet package` for read-only NuGet package search (not matched by existing `dotnet list`)
- Adds scoped `gh` CLI rules (`gh pr create`, `gh pr view`, `gh pr list`, `gh run view`) for PR creation and status checks

`git push` and `rm` remain in `ask` — both destructive or affecting shared state.

## Test plan

- [ ] Verify `dotnet-coverage collect` runs without a permission prompt
- [ ] Verify `reportgenerator` runs without a permission prompt
- [ ] Verify `gh pr create` runs without a permission prompt
- [ ] Verify `git push` still prompts for confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)