### PR TITLE
Hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -106,7 +106,7 @@
           {
             "type": "command",
             "if": "Bash(git commit:*)",
-            "command": "STAGED=$(git diff --cached --name-only | grep \"[.]cs$\"); [ -z \"$STAGED\" ] && exit 0; dotnet format style && dotnet format whitespace && echo \"$STAGED\" | xargs git add",
+            "command": "STAGED=$(git diff --cached --name-only | grep \"[.]cs$\"); [ -z \"$STAGED\" ] && exit 0; INCLUDE=$(echo \"$STAGED\" | tr '\\n' ' '); dotnet format style --include $INCLUDE && dotnet format whitespace --include $INCLUDE && echo \"$STAGED\" | xargs -d '\\n' git add",
             "statusMessage": "Formatting staged .cs files..."
           },
           {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -96,5 +96,27 @@
       "Read(**/appsettings.*.json)",
       "Read(**/appsettings.json)"
     ]
+  },
+
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit:*)",
+            "command": "STAGED=$(git diff --cached --name-only | grep \"[.]cs$\"); [ -z \"$STAGED\" ] && exit 0; dotnet format style && dotnet format whitespace && echo \"$STAGED\" | xargs git add",
+            "statusMessage": "Formatting staged .cs files..."
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh pr create:*)",
+            "command": "dotnet build && dotnet test",
+            "statusMessage": "Running build and tests before PR creation..."
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'claude-code[bot]') ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,8 @@
 name: Claude Code
 
 on:
+  pull_request:
+    types: [opened]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -13,6 +15,7 @@ on:
 jobs:
   claude:
     if: |
+      (github.event_name == 'pull_request') ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||

--- a/docs/cir/007-local-claude-hooks.md
+++ b/docs/cir/007-local-claude-hooks.md
@@ -1,0 +1,29 @@
+# CIR-007: Local-Only Claude Code Hooks
+
+**Intent:** Document the deliberate decision to implement code quality gates as Claude Code hooks in `.claude/settings.json` rather than as CI enforcement or git hooks, and capture the scope constraints this implies.
+
+**Behaviour:**
+
+- Given a developer is using Claude Code locally and has staged `.cs` files for commit
+- When Claude Code runs `git commit`
+- Then `dotnet format style` and `dotnet format whitespace` run automatically against only the staged files before the commit proceeds
+
+- Given a developer is using Claude Code locally and is about to raise a PR
+- When Claude Code runs `gh pr create`
+- Then `dotnet build` and `dotnet test` run automatically before the PR is created
+
+**Constraints:**
+
+- Claude Code hooks run in the Claude Code local session only — they are not git hooks and do not execute when committing directly via `git commit` in a terminal
+- These hooks do not run in CI (GitHub Actions); enforcement there relies on the build and test steps in existing workflows
+- The hooks fire as `PreToolUse` on matching `Bash(...)` tool calls made by Claude Code, not on any shell command run outside Claude Code
+
+**Decisions:**
+
+- **Rejected:** Standard git hooks (`.git/hooks/pre-commit`) — git hooks are not version-controlled by default and require manual setup per-clone (or tooling like `husky`). Claude Code hooks live in `.claude/settings.json`, are committed with the repo, and are automatically active for any developer using Claude Code without any extra setup step.
+
+- **Rejected:** CI-only enforcement — CI runs after a push; hooks catch issues at the point of commit or PR creation, giving faster feedback without requiring a CI round-trip. CI remains the safety net for commits made outside Claude Code.
+
+- **Chosen:** Claude Code `PreToolUse` hooks — provides zero-setup local enforcement for the primary development workflow (Claude Code), while accepting that developers committing directly via git bypass these gates. This trade-off is acceptable given that CI enforces build and test correctness regardless of how the commit was created.
+
+**Date:** 2026-04-13


### PR DESCRIPTION
## Summary

Adds two PreToolUse hooks to the project settings and enables automatic Claude review on PR creation. The hooks enforce code quality gates locally before commits and PRs are raised, removing the need to run formatting and tests manually. The workflow change removes the requirement to manually comment \`@claude\` to trigger a review when a PR is opened.

## Spec

N/A

## Changed Files

- .claude/settings.json
- .github/workflows/claude.yml