### PR TITLE
Dont Auto Review New Issues

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -7,8 +7,6 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
   pull_request_review:
     types: [submitted]
 
@@ -18,12 +16,11 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'claude-code[bot]') ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs


### PR DESCRIPTION
## Summary

Removes the `issues: [opened, assigned]` trigger and corresponding job condition from the Claude GitHub Actions workflow. Previously, Claude was automatically invoked whenever a new issue was opened or assigned, which was unintended behaviour. The change ensures Claude only responds when explicitly mentioned via `@claude` in comments or reviews. Also upgrades the `pull-requests` permission from `read` to `write` to allow Claude to post review comments on PRs.

## Spec

N/A

## Changed Files

.github/workflows/claude.yml